### PR TITLE
Add event timetables to the API

### DIFF
--- a/src/app/Http/Controllers/Api/Events/EventsController.php
+++ b/src/app/Http/Controllers/Api/Events/EventsController.php
@@ -93,9 +93,15 @@ class EventsController extends Controller
             ];
         }
 
-        // $timetables = array();
-        // foreach ($event->timetables as $timetable) {
-        // }
+        $timetables = array();
+        foreach ($event->timetables as $timetable) {
+            $timetables[] = [
+                'name' => $timetable->name,
+                'slug' => $timetable->slug,
+                'default' => (bool) $timetable->primary,
+                'url' => config('app.url') . '/api/events/' . $event->slug . '/timetables/' . $timetable->slug,
+            ];
+        }
 
         $formattedResponse = [
             'name' => $event->display_name,
@@ -119,11 +125,11 @@ class EventsController extends Controller
                 'base' => config('app.url') . '/events/' . $event->slug,
                 'tickets' => '#tickets',
                 'participants' => '#participants',
-                'timetables' => '#timetables',
+                'timetables' => config('app.url') . '/api/events/' . $event->slug . '/timetables',
             ],
             'participants' => $participants,
             'tickets' => $tickets,
-            // 'timetables' => $event->timetables
+            'timetables' => $timetables,
         ];
 
         return $formattedResponse;

--- a/src/app/Http/Controllers/Api/Events/TimetablesController.php
+++ b/src/app/Http/Controllers/Api/Events/TimetablesController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api\Events;
+
+use App\Models\Event;
+
+use App\Http\Controllers\Controller;
+
+class TimetablesController extends Controller
+{
+    public function index($event)
+    {
+        $event = $this->resolveEvent($event);
+
+        $return = [];
+        foreach ($event->timetables as $timetable) {
+            $return[] = $this->formatTimetable($timetable);
+        }
+        return $return;
+    }
+
+    public function showPrimary($event)
+    {
+        $event = $this->resolveEvent($event);
+
+        $timetable = $event->timetables()->where('primary', true)->first();
+
+        if (!$timetable) {
+            abort(404);
+        }
+
+        return $this->formatTimetable($timetable);
+    }
+
+    public function show($event, $timetable)
+    {
+        $event = $this->resolveEvent($event);
+
+        $timetable = $event->timetables()->where('slug', $timetable)->first()
+            ?? $event->timetables()->where('id', $timetable)->first();
+
+        if (!$timetable) {
+            abort(404);
+        }
+
+        return $this->formatTimetable($timetable);
+    }
+
+    private function resolveEvent($event)
+    {
+        if (is_numeric($event)) {
+            $resolved = Event::where('id', $event)->first();
+        } else {
+            $resolved = Event::where('slug', $event)->first();
+        }
+
+        if (!$resolved) {
+            abort(404);
+        }
+
+        return $resolved;
+    }
+
+    private function formatTimetable($timetable)
+    {
+        $data = [];
+        foreach ($timetable->data as $entry) {
+            $data[] = [
+                'start_time' => $entry->start_time,
+                'name' => $entry->name,
+                'description' => $entry->desc,
+            ];
+        }
+
+        return [
+            'name' => $timetable->name,
+            'slug' => $timetable->slug,
+            'status' => $timetable->status,
+            'default' => (bool) $timetable->primary,
+            'data' => $data,
+        ];
+    }
+}

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -8,6 +8,9 @@ Route::group(['middleware' => ['api']], function () {
     Route::get('/api/events/upcoming', 'Api\Events\EventsController@showUpcoming');
     Route::get('/api/events/next', 'Api\Events\EventsController@showNext');
     Route::get('/api/events/{event}', 'Api\Events\EventsController@show');
+    Route::get('/api/events/{event}/timetables', 'Api\Events\TimetablesController@index');
+    Route::get('/api/events/{event}/timetables/default', 'Api\Events\TimetablesController@showPrimary');
+    Route::get('/api/events/{event}/timetables/{timetable}', 'Api\Events\TimetablesController@show');
 });
 
 /**


### PR DESCRIPTION
- New endpoints: GET /api/events/{event}/timetables, /timetables/default, /timetables/{timetable}
- Timetable list included in event response with name, slug, default flag, and URL
- /timetables/default resolves the primary timetable (404 if none set)
- Respects existing EventTimetable global scope (DRAFT timetables hidden from non-admins)